### PR TITLE
fix: Maximum call stack size exceeded with array.push

### DIFF
--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -299,7 +299,9 @@ export class StarknetProvider extends BaseProvider {
         nextSource => !lastSources.find(lastSource => lastSource.contract === nextSource.contract)
       );
 
-      sourcesQueue.push(...newSources);
+      for (let i = 0; i < newSources.length; i++) {
+        sourcesQueue.push(newSources[i]);
+      }
       lastSources = nextSources;
     }
 
@@ -318,7 +320,9 @@ export class StarknetProvider extends BaseProvider {
         continuation_token: continuationToken
       });
 
-      events.push(...result.events);
+      for (let i = 0; i < result.events.length; i++) {
+        events.push(result.events[i]);
+      }
 
       continuationToken = result.continuation_token;
     } while (continuationToken);
@@ -357,7 +361,9 @@ export class StarknetProvider extends BaseProvider {
         continuation_token: continuationToken
       });
 
-      events.push(...result.events);
+      for (let i = 0; i < result.events.length; i++) {
+        events.push(result.events[i]);
+      }
 
       continuationToken = result.continuation_token;
     } while (continuationToken);
@@ -377,7 +383,9 @@ export class StarknetProvider extends BaseProvider {
         toBlock,
         source.contract
       );
-      events.push(...addressEvents);
+      for (let i = 0; i < addressEvents.length; i++) {
+        events.push(addressEvents[i]);
+      }
     }
 
     return events;


### PR DESCRIPTION
 (Bug: last_indexed_block reset to Zero after reaching the seed blocks #300)

When indexing contracts with a big number of events the array.push method will throw an error.

When you use spread operator all items of the source array are stored in the stack as arguments list, so having a large number of items (~ > 100K) will cause the this stack size exceed.

The most simple work-around is to manually push all items one by one.